### PR TITLE
Reduce mobile lag in advanced stages

### DIFF
--- a/main.js
+++ b/main.js
@@ -309,14 +309,20 @@ function update() {
     handleSpawning(now);
     updateAbilityCooldown(now);
     updateArrowMovement();
-    
-    updateBurgers();
-    updateIngredients();
+
+    // Read the player's rect once per frame; every collision pass reuses it
+    // instead of triggering its own layout reflow.
+    state.playerRect = DOM.player.getBoundingClientRect();
+
+    // Move bullets first so their cached rects are fresh for the collision
+    // passes (burgers/asteroids/enemies) that follow.
     updateBullets();
     updateEnemyBullets();
+    updateBurgers();
+    updateIngredients();
     updateAsteroids();
     updateEnemies(now);
-    
+
     requestAnimationFrame(update);
 }
 

--- a/systems.js
+++ b/systems.js
@@ -1,4 +1,4 @@
-import { DOM, state, INGREDIENT_TYPES } from './data.js';
+import { DOM, state, INGREDIENT_TYPES, deviceMode } from './data.js';
 
 // ===== PLAYER SYSTEMS =====
 
@@ -38,8 +38,7 @@ export function damagePlayer(amount) {
     }
 
     state.playerHP -= amount;
-    console.log(`💥 [DAMAGE] -${amount} HP | Now: ${state.playerHP}/${state.playerMaxHP}`);
-    
+
     // Check if player should lose weight
     if (state.isPlayerFat && state.playerHP < state.playerMaxHP - 1) {
         state.isPlayerFat = false;
@@ -81,7 +80,6 @@ export function damagePlayer(amount) {
 export function healPlayer(percent) {
     const amount = state.playerMaxHP * (percent / 100);
     state.playerHP = Math.min(state.playerMaxHP, state.playerHP + amount);
-    console.log(`💚 [HEAL] +${percent}% | Now: ${state.playerHP}/${state.playerMaxHP}`);
     updateHPUI();
     showFloatingMessage(`REPAIR +${percent}%`, state.playerX, DOM.wrapper.clientHeight - 100, "var(--health)");
 }
@@ -127,7 +125,12 @@ export function shoot() {
 
 export function enemyShoot(en) {
     if (!state.active) return;
-    
+
+    // Cap live enemy bullets so a screen full of fast-firing enemies in
+    // advanced stages can't snowball into hundreds of moving elements.
+    const ebCap = deviceMode.isMobile ? 70 : 160;
+    if (state.enemyBullets.length >= ebCap) return;
+
     const eb = document.createElement('div');
     eb.className = 'enemy-bullet';
     if (en.type === 'orange') eb.style.background = 'var(--elite)';
@@ -148,10 +151,8 @@ export function enemyShoot(en) {
             eb.dataset.chaoticShot = "true";
             eb.style.background = '#00f2ff';
             eb.style.boxShadow = '0 0 10px #00f2ff';
-            console.log(`🃏 [CHAOTIC] Enemy at Y=${en.y.toFixed(0)} shooting at normal enemy at Y=${targetEnemy.y.toFixed(0)}`);
         } else {
             // No normal enemies, don't shoot
-            console.log(`🃏 [CHAOTIC] Enemy at Y=${en.y.toFixed(0)} has no normal enemies to target`);
             return;
         }
     } else if (Math.random() < 0.05 && state.enemies.length > 1) {
@@ -195,20 +196,34 @@ export function enemyShoot(en) {
 
 // ===== VISUAL EFFECTS =====
 
+// Particle budget — caps the number of live particle elements so heavy
+// moments (mass kills, abilities) in advanced stages don't flood the DOM
+// with animated elements and cause lag spikes, especially on mobile.
+let activeParticles = 0;
+function particleCap() { return deviceMode.isMobile ? 70 : 180; }
+
+export function spawnParticle(x, y, color, opts = {}) {
+    if (activeParticles >= particleCap()) return;
+    activeParticles++;
+    const p = document.createElement('div');
+    p.className = 'particle';
+    p.style.background = color;
+    p.style.left = x + 'px';
+    p.style.top = y + 'px';
+    if (opts.size) { p.style.width = opts.size + 'px'; p.style.height = opts.size + 'px'; }
+    DOM.wrapper.appendChild(p);
+    const angle = Math.random() * Math.PI * 2;
+    const dist = Math.random() * (opts.dist || 60) + 10;
+    p.animate([
+        { opacity: 1 },
+        { transform: `translate(${Math.cos(angle)*dist}px, ${Math.sin(angle)*dist}px)`, opacity: 0 }
+    ], opts.duration || 500).onfinish = () => { p.remove(); activeParticles--; };
+}
+
 export function createExplosion(x, y, color) {
-    for(let i=0; i<15; i++) {
-        const p = document.createElement('div');
-        p.className = 'particle';
-        p.style.background = color;
-        p.style.left = x + 'px';
-        p.style.top = y + 'px';
-        DOM.wrapper.appendChild(p);
-        const angle = Math.random() * Math.PI * 2;
-        const dist = Math.random() * 60 + 10;
-        p.animate([
-            { opacity: 1 }, 
-            { transform: `translate(${Math.cos(angle)*dist}px, ${Math.sin(angle)*dist}px)`, opacity: 0 }
-        ], 500).onfinish = () => p.remove();
+    const count = deviceMode.isMobile ? 6 : 12;
+    for(let i=0; i<count; i++) {
+        spawnParticle(x, y, color);
     }
 }
 
@@ -492,6 +507,11 @@ export function handleSpawning(now) {
                 rotSpeed: Math.random() * 8 - 4 
             });
         } else {
+            // Don't keep spawning enemies once the screen is already saturated —
+            // this prevents the runaway lag spiral in advanced stages.
+            const enemyCap = deviceMode.isMobile ? 35 : 70;
+            if (state.enemies.length >= enemyCap) { state.lastSpawn = now; return; }
+
             const orangeChance = Math.min(0.8, 0.25 + (state.level * 0.05));
             const isOrange = Math.random() < orangeChance; 
             const type = isOrange ? 'orange' : 'red';

--- a/updates.js
+++ b/updates.js
@@ -1,5 +1,5 @@
-import { DOM, state, gameRules } from './data.js';
-import { damagePlayer, updateHPUI, enemyShoot, createExplosion, showFloatingMessage, healPlayer, spawnIngredients } from './systems.js';
+import { DOM, state, gameRules, deviceMode } from './data.js';
+import { damagePlayer, updateHPUI, enemyShoot, createExplosion, spawnParticle, showFloatingMessage, healPlayer, spawnIngredients } from './systems.js';
 
 // ===== UPDATE BULLETS =====
 
@@ -18,12 +18,13 @@ export function updateBullets() {
             
             b.el.style.left = newLeft + 'px';
             b.el.style.top = newTop + 'px';
-            
+
             // Remove if out of bounds
-            if (newTop < -50 || newTop > DOM.wrapper.clientHeight + 50 || 
+            if (newTop < -50 || newTop > DOM.wrapper.clientHeight + 50 ||
                 newLeft < -50 || newLeft > DOM.wrapper.clientWidth + 50) {
                 b.el.remove();
                 state.bullets.splice(i, 1);
+                continue;
             }
         } else {
             // Regular bullets
@@ -32,8 +33,14 @@ export function updateBullets() {
             if(b.y > DOM.wrapper.clientHeight) {
                 b.el.remove();
                 state.bullets.splice(i, 1);
+                continue;
             }
         }
+
+        // Cache the bullet's screen rect once per frame so the collision
+        // loops (enemies/asteroids/burgers) reuse it instead of forcing a
+        // layout reflow on every bullet×target pair (the main mobile lag).
+        b.rect = b.el.getBoundingClientRect();
     }
 }
 
@@ -45,8 +52,8 @@ export function updateEnemyBullets() {
         eb.el.style.left = eb.x + 'px';
         eb.el.style.top = eb.y + 'px';
         const ebRect = eb.el.getBoundingClientRect();
-        const pRect = DOM.player.getBoundingClientRect();
-        
+        const pRect = state.playerRect || DOM.player.getBoundingClientRect();
+
         // Check collision with player (only non-friendly and non-chaotic bullets)
         if (!eb.friendly && !eb.chaotic) {
             if(!(ebRect.right < pRect.left || ebRect.left > pRect.right || ebRect.bottom < pRect.top || ebRect.top > pRect.bottom)) {
@@ -63,7 +70,7 @@ export function updateEnemyBullets() {
             let hitAsteroid = false;
             for (let ai = state.asteroids.length - 1; ai >= 0; ai--) {
                 let ast = state.asteroids[ai];
-                const aRect = ast.el.getBoundingClientRect();
+                const aRect = ast.rect || ast.el.getBoundingClientRect();
                 if(!(ebRect.right < aRect.left || ebRect.left > aRect.right || ebRect.bottom < aRect.top || ebRect.top > aRect.bottom)) {
                     createExplosion(eb.x, eb.y, '#666');
                     eb.el.remove();
@@ -82,15 +89,13 @@ export function updateEnemyBullets() {
                 let targetEn = state.enemies[ei];
                 // Only hit non-chaotic enemies, and don't hit the shooter itself
                 if (targetEn.isChaotic || targetEn.el === eb.shooterId) continue;
-                
-                const teRect = targetEn.el.getBoundingClientRect();
+
+                const teRect = targetEn.rect || targetEn.el.getBoundingClientRect();
                 if(!(ebRect.right < teRect.left || ebRect.left > teRect.right || ebRect.bottom < teRect.top || ebRect.top > teRect.bottom)) {
                     // Damage the target enemy
                     targetEn.hp -= 1;
                     targetEn.hpFill.style.width = (targetEn.hp / targetEn.maxHP * 100) + '%';
-                    
-                    console.log(`💥 [CHAOTIC HIT] Normal enemy hit! HP: ${targetEn.hp}/${targetEn.maxHP}`);
-                    
+
                     createExplosion(eb.x, eb.y, '#00f2ff');
                     
                     // Kill enemy if HP reaches 0
@@ -103,9 +108,8 @@ export function updateEnemyBullets() {
                         showFloatingMessage(`+${points}`, teRect.left, teRect.top, '#00f2ff');
                         targetEn.el.remove();
                         state.enemies.splice(ei, 1);
-                        console.log(`☠️ [CHAOTIC KILL] Normal enemy killed! +${points} points`);
                     }
-                    
+
                     eb.el.remove();
                     state.enemyBullets.splice(i, 1);
                     hitEnemy = true;
@@ -120,11 +124,11 @@ export function updateEnemyBullets() {
             let hitEnemy = false;
             for (let ei = state.enemies.length - 1; ei >= 0; ei--) {
                 let targetEn = state.enemies[ei];
-                const teRect = targetEn.el.getBoundingClientRect();
+                const teRect = targetEn.rect || targetEn.el.getBoundingClientRect();
                 if(!(ebRect.right < teRect.left || ebRect.left > teRect.right || ebRect.bottom < teRect.top || ebRect.top > teRect.bottom)) {
                     targetEn.hp -= 1;
                     targetEn.hpFill.style.width = (targetEn.hp / targetEn.maxHP * 100) + '%';
-                    
+
                     if (targetEn.hp <= 0) {
                         const isElite = targetEn.type === 'orange';
                         const points = isElite ? 75 : 25;
@@ -161,7 +165,7 @@ export function updateBurgers() {
         bgr.y += bgr.speed;
         bgr.el.style.top = bgr.y + 'px';
         const bRect = bgr.el.getBoundingClientRect();
-        const pRect = DOM.player.getBoundingClientRect();
+        const pRect = state.playerRect || DOM.player.getBoundingClientRect();
         
         if(!(bRect.right < pRect.left || bRect.left > pRect.right || bRect.bottom < pRect.top || bRect.top > pRect.bottom)) {
             const wasFullHP = (state.playerHP >= state.playerMaxHP);
@@ -187,7 +191,7 @@ export function updateBurgers() {
 
         for (let bi = state.bullets.length - 1; bi >= 0; bi--) {
             let bul = state.bullets[bi];
-            const bulRect = bul.el.getBoundingClientRect();
+            const bulRect = bul.rect || bul.el.getBoundingClientRect();
             if(!(bulRect.right < bRect.left || bulRect.left > bRect.right || bulRect.bottom < bRect.top || bulRect.top > bRect.bottom)) {
                 const damage = bul.damage || 1.0;
                 bgr.hp -= damage;
@@ -230,7 +234,7 @@ export function updateIngredients() {
         ing.el.style.top = ing.y + 'px';
         
         const iRect = ing.el.getBoundingClientRect();
-        const pRect = DOM.player.getBoundingClientRect();
+        const pRect = state.playerRect || DOM.player.getBoundingClientRect();
         if(!(iRect.right < pRect.left || iRect.left > pRect.right || iRect.bottom < pRect.top || iRect.top > pRect.bottom)) {
             state.score += 25;
             DOM.scoreEl.innerText = state.score;
@@ -257,8 +261,8 @@ export function updateAsteroids() {
         ast.rot += ast.rotSpeed;
         ast.el.style.top = ast.y + 'px';
         ast.el.style.transform = `rotate(${ast.rot}deg)`;
-        const aRect = ast.el.getBoundingClientRect();
-        const pRect = DOM.player.getBoundingClientRect();
+        const aRect = ast.rect = ast.el.getBoundingClientRect();
+        const pRect = state.playerRect || DOM.player.getBoundingClientRect();
         
         if(!(aRect.right < pRect.left || aRect.left > pRect.right || aRect.bottom < pRect.top || aRect.top > pRect.bottom)) {
             damagePlayer(40);
@@ -272,7 +276,7 @@ export function updateAsteroids() {
         if (!gameRules.playerShootThroughAsteroids) {
             for (let bi = state.bullets.length - 1; bi >= 0; bi--) {
                 let bul = state.bullets[bi];
-                const bRect = bul.el.getBoundingClientRect();
+                const bRect = bul.rect || bul.el.getBoundingClientRect();
                 if(!(bRect.right < aRect.left || bRect.left > aRect.right || bRect.bottom < aRect.top || bRect.top > aRect.bottom)) {
                     createExplosion(bRect.left, bRect.top, '#666');
                     bul.el.remove();
@@ -296,7 +300,10 @@ export function updateEnemies(now) {
         let en = state.enemies[i];
         en.y += en.speed;
         en.el.style.top = en.y + 'px';
-        
+        // Cache this enemy's rect once per frame instead of recomputing it
+        // for every player bullet (was an O(enemies×bullets) layout thrash).
+        en.rect = en.el.getBoundingClientRect();
+
         if (now - en.lastShot > en.fireRate) {
             enemyShoot(en);
             en.lastShot = now;
@@ -312,39 +319,27 @@ export function updateEnemies(now) {
             continue;
         }
 
+        const eRect = en.rect;
         for (let bi = state.bullets.length - 1; bi >= 0; bi--) {
             let bul = state.bullets[bi];
-            const bRect = bul.el.getBoundingClientRect();
-            const eRect = en.el.getBoundingClientRect();
-            
+            const bRect = bul.rect || bul.el.getBoundingClientRect();
+
             if(!(bRect.right < eRect.left || bRect.left > eRect.right || bRect.bottom < eRect.top || bRect.top > eRect.bottom)) {
                 const damage = bul.damage || 1.0;
                 
                 // Phoenix Feather explosion - damages nearby enemies
                 if (bul.isFeather) {
-                    // Create big explosion
-                    for(let e=0; e<30; e++) {
-                        const p = document.createElement('div');
-                        p.className = 'particle';
-                        p.style.background = e % 3 === 0 ? '#ffd700' : '#ff6b35';
-                        p.style.left = bRect.left + 'px';
-                        p.style.top = bRect.top + 'px';
-                        p.style.width = '6px';
-                        p.style.height = '6px';
-                        DOM.wrapper.appendChild(p);
-                        const angle = Math.random() * Math.PI * 2;
-                        const dist = Math.random() * 120 + 30;
-                        p.animate([
-                            { opacity: 1 }, 
-                            { transform: `translate(${Math.cos(angle)*dist}px, ${Math.sin(angle)*dist}px)`, opacity: 0 }
-                        ], 700).onfinish = () => p.remove();
+                    // Create big explosion (capped particle budget)
+                    const fCount = deviceMode.isMobile ? 12 : 24;
+                    for(let e=0; e<fCount; e++) {
+                        spawnParticle(bRect.left, bRect.top, e % 3 === 0 ? '#ffd700' : '#ff6b35', { size: 6, dist: 120, duration: 700 });
                     }
-                    
+
                     // Damage all enemies in radius (150px)
                     const explosionRadius = 150;
                     for (let ei = state.enemies.length - 1; ei >= 0; ei--) {
                         let targetEn = state.enemies[ei];
-                        const teRect = targetEn.el.getBoundingClientRect();
+                        const teRect = targetEn.rect || targetEn.el.getBoundingClientRect();
                         const dx = (teRect.left + 25) - (bRect.left + 10);
                         const dy = (teRect.top + 25) - (bRect.top + 20);
                         const dist = Math.sqrt(dx*dx + dy*dy);


### PR DESCRIPTION
Cut the per-frame work that grows with entity count, which was causing heavy lag on phones in later levels:

- Cache getBoundingClientRect() results once per frame (player, bullets, enemies, asteroids) instead of recomputing them inside nested collision loops. This removes the O(n*m) layout-reflow thrash that was the main source of frame drops when the screen filled up.
- Cap and reuse the particle budget (fewer particles on mobile) so mass kills and abilities no longer flood the DOM with animated elements.
- Cap live enemies and enemy bullets to stop the late-game lag spiral.
- Remove hot-path console.log calls (damage, heal, chaotic hits) that fired many times per second.