### PR TITLE
leaderboard: show only one entry per player (personal best)

### DIFF
--- a/data.js
+++ b/data.js
@@ -422,26 +422,29 @@ export async function saveScore(skinKey, score, level, userName = null) {
     console.log(`💾 [SCORE] Saving: ${score} pts, Level ${level}, User: ${userName || 'Anonymous'}`);
     
     // Save to cookies (local)
+    const effectiveName = userName || 'Anonymous';
     let skinLeaderboard = getLeaderboard(skinKey);
-    const newEntry = { 
-        score, 
-        level, 
-        userName: userName || 'Anonymous',
-        date: new Date().toLocaleDateString('he-IL') 
+    const newEntry = {
+        score,
+        level,
+        userName: effectiveName,
+        date: new Date().toLocaleDateString('he-IL')
     };
+    skinLeaderboard = skinLeaderboard.filter(e => e.userName !== effectiveName);
     skinLeaderboard.push(newEntry);
     skinLeaderboard.sort((a, b) => b.score - a.score);
     skinLeaderboard = skinLeaderboard.slice(0, 5);
     setCookie(`leaderboard_${skinKey}`, JSON.stringify(skinLeaderboard));
-    
+
     let overallLeaderboard = getLeaderboard('overall');
-    const overallEntry = { 
-        score, 
-        level, 
-        skin: skinKey, 
-        userName: userName || 'Anonymous',
-        date: new Date().toLocaleDateString('he-IL') 
+    const overallEntry = {
+        score,
+        level,
+        skin: skinKey,
+        userName: effectiveName,
+        date: new Date().toLocaleDateString('he-IL')
     };
+    overallLeaderboard = overallLeaderboard.filter(e => e.userName !== effectiveName);
     overallLeaderboard.push(overallEntry);
     overallLeaderboard.sort((a, b) => b.score - a.score);
     overallLeaderboard = overallLeaderboard.slice(0, 5);

--- a/firestore-sync.js
+++ b/firestore-sync.js
@@ -185,11 +185,19 @@ export async function saveScoreToCloud(skinKey, score, level, userName) {
             date: new Date().toLocaleDateString('he-IL')
         };
         
-        // שמירה ב-leaderboard הכללי
-        await addDoc(collection(db, 'leaderboard'), scoreData);
-        
-        // שמירה ב-leaderboard לפי סקין
-        await addDoc(collection(db, `scores/${skinKey}/entries`), scoreData);
+        // שמירה ב-leaderboard הכללי - רק שיא אחד למשתמש
+        const overallRef = doc(db, 'leaderboard', user.uid);
+        const existingOverall = await getDoc(overallRef);
+        if (!existingOverall.exists() || score > existingOverall.data().score) {
+            await setDoc(overallRef, scoreData);
+        }
+
+        // שמירה ב-leaderboard לפי סקין - רק שיא אחד למשתמש
+        const skinRef = doc(db, `scores/${skinKey}/entries`, user.uid);
+        const existingSkin = await getDoc(skinRef);
+        if (!existingSkin.exists() || score > existingSkin.data().score) {
+            await setDoc(skinRef, scoreData);
+        }
         
         // עדכון סטטיסטיקות משתמש
         const userStatsRef = doc(db, 'userStats', user.uid);
@@ -244,26 +252,38 @@ export async function getLeaderboardFromCloud(skinKey = 'overall') {
             q = query(
                 collection(db, 'leaderboard'),
                 orderBy('score', 'desc'),
-                limit(10)
+                limit(50)
             );
         } else {
             q = query(
                 collection(db, `scores/${skinKey}/entries`),
                 orderBy('score', 'desc'),
-                limit(10)
+                limit(50)
             );
         }
-        
+
         const querySnapshot = await getDocs(q);
-        const scores = [];
-        
+        const allScores = [];
+
         querySnapshot.forEach((doc) => {
-            scores.push({
+            allScores.push({
                 id: doc.id,
                 ...doc.data()
             });
         });
-        
+
+        // deduplicate: keep only the best score per user
+        const seen = new Set();
+        const scores = [];
+        for (const entry of allScores) {
+            const uid = entry.userId || entry.id;
+            if (!seen.has(uid)) {
+                seen.add(uid);
+                scores.push(entry);
+                if (scores.length === 10) break;
+            }
+        }
+
         console.log(`✅ [CLOUD] Fetched ${scores.length} scores`);
         return scores;
     } catch (error) {


### PR DESCRIPTION
Each user now appears at most once in the leaderboard, showing only their best score.
- Cloud: save uses setDoc with userId as doc ID, only updates when score improves
- Cloud: read deduplicates by userId to handle legacy duplicate data
- Local: filters out existing entry for same userName before inserting new one

https://claude.ai/code/session_01Ccgi8dUXC9YieQ8FuFWoNM