### PR TITLE
Add game settings view in leaderboard and full settings snapshot on save

### DIFF
--- a/data.js
+++ b/data.js
@@ -420,9 +420,9 @@ export function getLeaderboard(skinKey = 'overall') {
     return [];
 }
 
-export async function saveScore(skinKey, score, level, userName = null) {
+export async function saveScore(skinKey, score, level, userName = null, settings = null) {
     console.log(`💾 [SCORE] Saving: ${score} pts, Level ${level}, User: ${userName || 'Anonymous'}`);
-    
+
     // Save to cookies (local)
     const effectiveName = userName || 'Anonymous';
     let skinLeaderboard = getLeaderboard(skinKey);
@@ -430,7 +430,8 @@ export async function saveScore(skinKey, score, level, userName = null) {
         score,
         level,
         userName: effectiveName,
-        date: new Date().toLocaleDateString('he-IL')
+        date: new Date().toLocaleDateString('he-IL'),
+        settings: settings || null
     };
     skinLeaderboard = skinLeaderboard.filter(e => e.userName !== effectiveName);
     skinLeaderboard.push(newEntry);
@@ -444,17 +445,18 @@ export async function saveScore(skinKey, score, level, userName = null) {
         level,
         skin: skinKey,
         userName: effectiveName,
-        date: new Date().toLocaleDateString('he-IL')
+        date: new Date().toLocaleDateString('he-IL'),
+        settings: settings || null
     };
     overallLeaderboard = overallLeaderboard.filter(e => e.userName !== effectiveName);
     overallLeaderboard.push(overallEntry);
     overallLeaderboard.sort((a, b) => b.score - a.score);
     overallLeaderboard = overallLeaderboard.slice(0, 5);
     setCookie(`leaderboard_overall`, JSON.stringify(overallLeaderboard));
-    
+
     // Save to cloud
     try {
-        await saveScoreToCloud(skinKey, score, level, userName);
+        await saveScoreToCloud(skinKey, score, level, userName, settings);
         console.log('✅ [SCORE] Saved to cloud');
     } catch (error) {
         console.log('⚠️ [SCORE] Cloud save failed, local score saved');
@@ -519,7 +521,8 @@ export const state = {
         invincibleUntil: 0
     },
     isDebugGame: false,
-    paused: false
+    paused: false,
+    startTime: 0
 };
 
 export function resetState() {
@@ -570,5 +573,6 @@ export function resetState() {
     state.dragonAbility.invincibleUntil = 0;
     state.isDebugGame = false;
     state.paused = false;
+    state.startTime = Date.now();
     console.log('✅ [STATE] Reset complete');
 }

--- a/firestore-sync.js
+++ b/firestore-sync.js
@@ -158,7 +158,7 @@ export async function syncMaxLevel() {
 }
 
 // ===== SAVE SCORE TO FIRESTORE =====
-export async function saveScoreToCloud(skinKey, score, level, userName) {
+export async function saveScoreToCloud(skinKey, score, level, userName, settings = null) {
     if (!auth || !db) {
         console.error('❌ [CLOUD] Firebase not initialized');
         return false;
@@ -172,7 +172,7 @@ export async function saveScoreToCloud(skinKey, score, level, userName) {
 
     try {
         console.log(`☁️ [CLOUD] Saving score: ${score} pts, Level ${level}, Skin: ${skinKey}`);
-        
+
         // שמירה ב-collection הספציפי לסקין
         const scoreData = {
             userId: user.uid,
@@ -182,7 +182,8 @@ export async function saveScoreToCloud(skinKey, score, level, userName) {
             level: level,
             skin: skinKey,
             timestamp: serverTimestamp(),
-            date: new Date().toLocaleDateString('he-IL')
+            date: new Date().toLocaleDateString('he-IL'),
+            settings: settings || null
         };
         
         // שמירה ב-leaderboard הכללי - רק שיא אחד למשתמש

--- a/i18n.js
+++ b/i18n.js
@@ -156,6 +156,12 @@ const STRINGS = {
     quizCorrect:      { he: '✅ נכון!', en: '✅ Correct!', ar: '✅ صحيح!', ru: '✅ Правильно!', fr: '✅ Correct !', es: '✅ ¡Correcto!' },
     quizWrong:        { he: '❌ טעות. התשובה הנכונה מסומנת.', en: '❌ Wrong. The correct answer is highlighted.', ar: '❌ خطأ. الإجابة الصحيحة مظلّلة.', ru: '❌ Неверно. Правильный ответ выделен.', fr: '❌ Faux. La bonne réponse est surlignée.', es: '❌ Incorrecto. La respuesta correcta está resaltada.' },
 
+    // ---- Entry settings view ----
+    esTitle:          { he: '⚙️ הגדרות משחק', en: '⚙️ Game Settings', ar: '⚙️ إعدادات اللعبة', ru: '⚙️ Настройки игры', fr: '⚙️ Paramètres de jeu', es: '⚙️ Ajustes del juego' },
+    esFilterAll:      { he: 'הכל', en: 'All', ar: 'الكل', ru: 'Все', fr: 'Tout', es: 'Todo' },
+    esFallbackNote:   { he: '⚠️ הגדרות לא נשמרו למשחק ישן זה — מוצגות ההגדרות הנוכחיות שלך', en: '⚠️ Settings not saved for this old game — showing your current settings', ar: '⚠️ لم تُحفظ الإعدادات لهذه اللعبة القديمة — عرض إعداداتك الحالية', ru: '⚠️ Настройки не сохранены для этой старой игры — показаны ваши текущие настройки', fr: '⚠️ Paramètres non sauvegardés pour cette ancienne partie — affichage de vos paramètres actuels', es: '⚠️ Ajustes no guardados para esta partida antigua — mostrando tus ajustes actuales' },
+    esDuration:       { he: '⏱️ זמן משחק', en: '⏱️ Game duration', ar: '⏱️ مدة اللعبة', ru: '⏱️ Длительность', fr: '⏱️ Durée de partie', es: '⏱️ Duración' },
+
     // ---- Language tab ----
     langTabTitle:     { he: 'בחר שפה', en: 'Choose Language', ar: 'اختر اللغة', ru: 'Выберите язык', fr: 'Choisir la langue', es: 'Elegir idioma' },
     langLabel:        { he: 'שפה / Language:', en: 'Language / שפה:', ar: 'اللغة:', ru: 'Язык:', fr: 'Langue :', es: 'Idioma:' },

--- a/index.html
+++ b/index.html
@@ -134,6 +134,30 @@
                 <button onclick="closeLeaderboard()" style="margin-top: 15px;" data-i18n="lbBack">חזרה</button>
             </div>
 
+            <!-- Entry Settings View -->
+            <div id="entry-settings-container" style="display: none; width: 100%; max-width: 400px; text-align: center;">
+                <h2 style="margin-bottom: 8px;" data-i18n="esTitle">⚙️ הגדרות משחק</h2>
+                <div id="es-meta" style="font-size: 0.8rem; opacity: 0.7; margin-bottom: 4px;"></div>
+                <div id="es-duration" style="font-size: 0.8rem; opacity: 0.7; margin-bottom: 12px; display:none;"></div>
+
+                <div id="es-filters" style="display:flex; flex-wrap:wrap; gap:5px; margin-bottom:12px; justify-content:center;">
+                    <button class="es-filter active" data-cat="all" onclick="setEntrySettingsFilter('all')" data-i18n="esFilterAll">הכל</button>
+                    <button class="es-filter" data-cat="device" onclick="setEntrySettingsFilter('device')" data-i18n="tabDevice">📱 מכשיר</button>
+                    <button class="es-filter" data-cat="controls" onclick="setEntrySettingsFilter('controls')" data-i18n="tabControls">🎮 שליטה</button>
+                    <button class="es-filter" data-cat="rules" onclick="setEntrySettingsFilter('rules')" data-i18n="tabRules">📜 כללים</button>
+                    <button class="es-filter" data-cat="edu" onclick="setEntrySettingsFilter('edu')" data-i18n="tabEdu">📚 חינוכי</button>
+                    <button class="es-filter" data-cat="lang" onclick="setEntrySettingsFilter('lang')" data-i18n="tabLang">🌐 שפה</button>
+                </div>
+
+                <div id="es-body"></div>
+
+                <div id="es-fallback-note" style="display:none; margin-top:10px;">
+                    <small style="opacity: 0.6;" data-i18n="esFallbackNote">⚠️ הגדרות לא נשמרו — מוצגות ההגדרות הנוכחיות שלך</small>
+                </div>
+
+                <button onclick="closeEntrySettings()" style="margin-top: 15px;" data-i18n="settingsBack">◀ חזרה</button>
+            </div>
+
             <div id="main-menu">
             <div class="skin-selector">
                 <div class="skin-option selected" data-skin="classic">

--- a/main.js
+++ b/main.js
@@ -92,6 +92,9 @@ console.log('✅ [INIT] Game loaded successfully');
 
 // ===== LEADERBOARD =====
 
+let _currentLeaderboardEntries = [];
+let _esActiveFilter = 'all';
+
 function showLeaderboard() {
     console.log('🏆 [LEADERBOARD] Opening leaderboard...');
     console.log('🏆 [LEADERBOARD] Hiding main menu');
@@ -125,6 +128,139 @@ function closeLeaderboard() {
     document.getElementById('floating-settings-btn').style.display = 'flex';
     console.log('✅ [LEADERBOARD] Leaderboard closed');
 }
+
+// ===== ENTRY SETTINGS VIEW =====
+
+function showEntrySettings(idx) {
+    const entry = _currentLeaderboardEntries[idx];
+    if (!entry) return;
+
+    const isFallback = !entry.settings;
+    const s = entry.settings || {
+        isMobile: deviceMode.isMobile,
+        controlType: keyBindings.controlType,
+        shoot: keyBindings.shoot,
+        ability: keyBindings.ability,
+        rightClickAbility: keyBindings.rightClickAbility,
+        enemiesShootThroughAsteroids: gameRules.enemiesShootThroughAsteroids,
+        playerShootThroughAsteroids: gameRules.playerShootThroughAsteroids,
+        eduEnabled: eduConfig.enabled,
+        eduSubject: eduConfig.subject,
+        eduGrade: eduConfig.grade,
+        lang: currentLang,
+        gameDuration: null,
+        startTime: null
+    };
+
+    document.getElementById('leaderboard-container').style.display = 'none';
+    const container = document.getElementById('entry-settings-container');
+    container.style.display = 'block';
+
+    // Meta info
+    const skinName = SKINS[entry.skin]?.name || entry.skin || '';
+    document.getElementById('es-meta').textContent =
+        `👤 ${entry.userName || 'Anonymous'} | ${(entry.score || 0).toLocaleString()} pts | ${t('levelWord')} ${entry.level}${skinName ? ' • ' + skinName : ''} | ${entry.date || ''}`;
+
+    // Duration
+    const durationEl = document.getElementById('es-duration');
+    if (s.gameDuration) {
+        const mins = Math.floor(s.gameDuration / 60000);
+        const secs = Math.floor((s.gameDuration % 60000) / 1000);
+        durationEl.textContent = `${t('esDuration')}: ${mins}:${String(secs).padStart(2, '0')}`;
+        durationEl.style.display = 'block';
+    } else {
+        durationEl.style.display = 'none';
+    }
+
+    // Fallback note
+    document.getElementById('es-fallback-note').style.display = isFallback ? 'block' : 'none';
+
+    // Store settings on container for filter updates
+    container._esSettings = s;
+
+    // Reset filter to "all"
+    _esActiveFilter = 'all';
+    document.querySelectorAll('.es-filter').forEach(b => b.classList.toggle('active', b.dataset.cat === 'all'));
+    renderEntrySettingsBody(s, 'all');
+}
+
+function closeEntrySettings() {
+    document.getElementById('entry-settings-container').style.display = 'none';
+    document.getElementById('leaderboard-container').style.display = 'block';
+}
+
+function setEntrySettingsFilter(cat) {
+    _esActiveFilter = cat;
+    document.querySelectorAll('.es-filter').forEach(b => b.classList.toggle('active', b.dataset.cat === cat));
+    const container = document.getElementById('entry-settings-container');
+    renderEntrySettingsBody(container._esSettings || {}, cat);
+}
+
+function renderEntrySettingsBody(s, cat) {
+    const langInfo = LANGUAGES.find(l => l.code === s.lang) || LANGUAGES[0];
+    const subjects = getSubjects();
+    const subjName = subjects.find(sub => sub.key === s.eduSubject)?.name || s.eduSubject || '-';
+
+    const fmtKey = (code) => {
+        if (!code) return '?';
+        if (code === 'Space') return 'Space';
+        if (code.startsWith('Key')) return code.replace('Key', '');
+        if (code.startsWith('Digit')) return code.replace('Digit', '');
+        return code;
+    };
+
+    const bool = (v) => v
+        ? `<span class="es-val-yes">✅ ${currentLang === 'en' ? 'Yes' : 'כן'}</span>`
+        : `<span class="es-val-no">❌ ${currentLang === 'en' ? 'No' : 'לא'}</span>`;
+
+    const row = (label, value) =>
+        `<div class="es-row"><span class="es-label">${label}</span><span class="es-value">${value}</span></div>`;
+
+    const groups = {
+        device: `<div class="es-group" data-cat="device">
+            <div class="es-group-title">${t('tabDevice')}</div>
+            ${row(t('deviceLabel'), s.isMobile
+                ? `📱 ${t('deviceMobile').replace(/^📱\s*/, '')}`
+                : `🖥️ ${t('deviceDesktop').replace(/^🖥️\s*/, '')}`)}
+        </div>`,
+
+        controls: `<div class="es-group" data-cat="controls">
+            <div class="es-group-title">${t('tabControls')}</div>
+            ${row(t('controlLabel'), s.controlType === 'mouse' ? t('controlMouse') : t('controlArrows'))}
+            ${row(t('shootKeyLabel'), `<kbd>${fmtKey(s.shoot)}</kbd>`)}
+            ${row(t('abilityKeyLabel'), `<kbd>${fmtKey(s.ability)}</kbd>`)}
+            ${row(t('rightClickLabel'), bool(s.rightClickAbility))}
+        </div>`,
+
+        rules: `<div class="es-group" data-cat="rules">
+            <div class="es-group-title">${t('tabRules')}</div>
+            ${row(t('enemiesAsteLabel'), bool(s.enemiesShootThroughAsteroids))}
+            ${row(t('playerAsteLabel'), bool(s.playerShootThroughAsteroids))}
+        </div>`,
+
+        edu: `<div class="es-group" data-cat="edu">
+            <div class="es-group-title">${t('tabEdu')}</div>
+            ${row(t('eduOnOffLabel'), s.eduEnabled
+                ? `✅ ${t('eduOn').replace(/^✅\s*/, '')}`
+                : `❌ ${t('eduOff').replace(/^❌\s*/, '')}`)}
+            ${s.eduEnabled ? row(t('subjectLabel'), subjName) : ''}
+            ${s.eduEnabled ? row(t('gradeLabel_'), gradeLabel(s.eduGrade || '1')) : ''}
+        </div>`,
+
+        lang: `<div class="es-group" data-cat="lang">
+            <div class="es-group-title">${t('tabLang')}</div>
+            ${row(t('langLabel'), `${langInfo.flag} ${langInfo.name}`)}
+        </div>`
+    };
+
+    document.getElementById('es-body').innerHTML =
+        cat === 'all' ? Object.values(groups).join('') : (groups[cat] || '');
+}
+
+// Export to window for HTML onclick
+window.showEntrySettings = showEntrySettings;
+window.closeEntrySettings = closeEntrySettings;
+window.setEntrySettingsFilter = setEntrySettingsFilter;
 
 async function displayLeaderboard(category) {
     console.log(`📊 [DISPLAY] Displaying leaderboard for category: ${category}`);
@@ -164,25 +300,27 @@ async function displayLeaderboard(category) {
         return;
     }
     
+    _currentLeaderboardEntries = leaderboard;
+
     const medals = ['🥇', '🥈', '🥉', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', '🔟'];
     console.log('📊 [DISPLAY] Generating HTML for entries...');
     const html = leaderboard.map((entry, index) => {
         console.log(`📊 [DISPLAY] Entry ${index + 1}:`, entry);
-        
+
         // Get skin name, or use the skin key if skin doesn't exist in SKINS
         let skinName = '';
         if (entry.skin) {
             if (SKINS[entry.skin]) {
                 skinName = `• ${SKINS[entry.skin].name}`;
             } else {
-                skinName = `• ${entry.skin}`; // Fallback to skin key if skin doesn't exist
+                skinName = `• ${entry.skin}`;
                 console.warn(`⚠️ [DISPLAY] Unknown skin: ${entry.skin}`);
             }
         }
-        
+
         // Get user name
         const userName = entry.userName || 'Anonymous';
-        
+
         return `
         <div class="lb-entry rank-${index + 1}">
             <div class="lb-rank">${medals[index] || (index + 1)}</div>
@@ -195,6 +333,7 @@ async function displayLeaderboard(category) {
                     ${t('levelWord')} ${entry.level} ${skinName} • ${entry.date}
                 </div>
             </div>
+            <button class="lb-settings-btn" onclick="showEntrySettings(${index})" title="${t('esTitle')}">⚙️</button>
         </div>
     `;
     }).join('');

--- a/styles.css
+++ b/styles.css
@@ -527,6 +527,98 @@ button:hover {
     font-size: 0.9rem;
 }
 
+.lb-settings-btn {
+    padding: 6px 9px;
+    font-size: 1rem;
+    background: rgba(0,242,255,0.08);
+    border: 1px solid rgba(0,242,255,0.25);
+    color: var(--primary);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s;
+    flex-shrink: 0;
+}
+
+.lb-settings-btn:hover {
+    background: rgba(0,242,255,0.2);
+    border-color: var(--primary);
+}
+
+/* Entry Settings View */
+#es-body {
+    background: rgba(0,0,0,0.5);
+    border: 1px solid var(--primary);
+    border-radius: 10px;
+    padding: 10px 12px;
+    max-height: 260px;
+    overflow-y: auto;
+    text-align: start;
+}
+
+.es-filter {
+    padding: 5px 10px;
+    font-size: 0.72rem;
+    background: rgba(255,255,255,0.07);
+    border: 1px solid rgba(255,255,255,0.2);
+    color: rgba(255,255,255,0.65);
+    border-radius: 14px;
+    cursor: pointer;
+    transition: all 0.2s;
+    font-family: 'Orbitron', sans-serif;
+}
+
+.es-filter.active {
+    background: rgba(0,242,255,0.18);
+    border-color: var(--primary);
+    color: var(--primary);
+}
+
+.es-group {
+    margin-bottom: 12px;
+}
+
+.es-group-title {
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: var(--primary);
+    margin-bottom: 6px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid rgba(0,242,255,0.25);
+}
+
+.es-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 3px 0;
+    font-size: 0.78rem;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+
+.es-label {
+    color: rgba(255,255,255,0.55);
+    flex: 1;
+    padding-inline-end: 8px;
+}
+
+.es-value {
+    color: white;
+    font-weight: bold;
+    text-align: end;
+}
+
+.es-val-yes { color: #2ecc71; }
+.es-val-no  { color: #e74c3c; }
+
+kbd {
+    background: rgba(255,255,255,0.12);
+    border: 1px solid rgba(255,255,255,0.25);
+    border-radius: 3px;
+    padding: 1px 6px;
+    font-size: 0.72rem;
+    font-family: monospace;
+}
+
 /* Special Ability Button */
 #special-ability-btn {
     position: fixed;

--- a/systems.js
+++ b/systems.js
@@ -101,13 +101,31 @@ export function damagePlayer(amount) {
         if (pauseOverlay) pauseOverlay.style.display = 'none';
 
         if (!state.isDebugGame) {
-            import('./data.js').then(module => {
-                // Get username from auth module
-                import('./auth.js').then(authModule => {
-                    const userName = authModule.currentUser?.displayName || 'Anonymous';
-                    module.saveScore(module.currentSkinKey, state.score, state.level, userName);
-                    console.log(`✅ [GAME OVER] Score saved for user: ${userName}`);
-                });
+            const gameDuration = Date.now() - (state.startTime || Date.now());
+            Promise.all([
+                import('./data.js'),
+                import('./auth.js'),
+                import('./education.js'),
+                import('./i18n.js')
+            ]).then(([dataModule, authModule, eduModule, i18nModule]) => {
+                const userName = authModule.currentUser?.displayName || 'Anonymous';
+                const settings = {
+                    isMobile: dataModule.deviceMode.isMobile,
+                    controlType: dataModule.keyBindings.controlType,
+                    shoot: dataModule.keyBindings.shoot,
+                    ability: dataModule.keyBindings.ability,
+                    rightClickAbility: dataModule.keyBindings.rightClickAbility,
+                    enemiesShootThroughAsteroids: dataModule.gameRules.enemiesShootThroughAsteroids,
+                    playerShootThroughAsteroids: dataModule.gameRules.playerShootThroughAsteroids,
+                    eduEnabled: eduModule.eduConfig.enabled,
+                    eduSubject: eduModule.eduConfig.subject,
+                    eduGrade: eduModule.eduConfig.grade,
+                    lang: i18nModule.currentLang,
+                    gameDuration,
+                    startTime: state.startTime || null
+                };
+                dataModule.saveScore(dataModule.currentSkinKey, state.score, state.level, userName, settings);
+                console.log(`✅ [GAME OVER] Score saved for user: ${userName}`);
             }).catch(err => {
                 console.error('❌ [GAME OVER] Save error:', err);
             });

--- a/test/data.js
+++ b/test/data.js
@@ -420,9 +420,9 @@ export function getLeaderboard(skinKey = 'overall') {
     return [];
 }
 
-export async function saveScore(skinKey, score, level, userName = null) {
+export async function saveScore(skinKey, score, level, userName = null, settings = null) {
     console.log(`💾 [SCORE] Saving: ${score} pts, Level ${level}, User: ${userName || 'Anonymous'}`);
-    
+
     // Save to cookies (local)
     const effectiveName = userName || 'Anonymous';
     let skinLeaderboard = getLeaderboard(skinKey);
@@ -430,7 +430,8 @@ export async function saveScore(skinKey, score, level, userName = null) {
         score,
         level,
         userName: effectiveName,
-        date: new Date().toLocaleDateString('he-IL')
+        date: new Date().toLocaleDateString('he-IL'),
+        settings: settings || null
     };
     skinLeaderboard = skinLeaderboard.filter(e => e.userName !== effectiveName);
     skinLeaderboard.push(newEntry);
@@ -444,17 +445,18 @@ export async function saveScore(skinKey, score, level, userName = null) {
         level,
         skin: skinKey,
         userName: effectiveName,
-        date: new Date().toLocaleDateString('he-IL')
+        date: new Date().toLocaleDateString('he-IL'),
+        settings: settings || null
     };
     overallLeaderboard = overallLeaderboard.filter(e => e.userName !== effectiveName);
     overallLeaderboard.push(overallEntry);
     overallLeaderboard.sort((a, b) => b.score - a.score);
     overallLeaderboard = overallLeaderboard.slice(0, 5);
     setCookie(`leaderboard_overall`, JSON.stringify(overallLeaderboard));
-    
+
     // Save to cloud
     try {
-        await saveScoreToCloud(skinKey, score, level, userName);
+        await saveScoreToCloud(skinKey, score, level, userName, settings);
         console.log('✅ [SCORE] Saved to cloud');
     } catch (error) {
         console.log('⚠️ [SCORE] Cloud save failed, local score saved');
@@ -519,7 +521,8 @@ export const state = {
         invincibleUntil: 0
     },
     isDebugGame: false,
-    paused: false
+    paused: false,
+    startTime: 0
 };
 
 export function resetState() {
@@ -570,5 +573,6 @@ export function resetState() {
     state.dragonAbility.invincibleUntil = 0;
     state.isDebugGame = false;
     state.paused = false;
+    state.startTime = Date.now();
     console.log('✅ [STATE] Reset complete');
 }

--- a/test/firestore-sync.js
+++ b/test/firestore-sync.js
@@ -158,7 +158,7 @@ export async function syncMaxLevel() {
 }
 
 // ===== SAVE SCORE TO FIRESTORE =====
-export async function saveScoreToCloud(skinKey, score, level, userName) {
+export async function saveScoreToCloud(skinKey, score, level, userName, settings = null) {
     if (!auth || !db) {
         console.error('❌ [CLOUD] Firebase not initialized');
         return false;
@@ -172,7 +172,7 @@ export async function saveScoreToCloud(skinKey, score, level, userName) {
 
     try {
         console.log(`☁️ [CLOUD] Saving score: ${score} pts, Level ${level}, Skin: ${skinKey}`);
-        
+
         // שמירה ב-collection הספציפי לסקין
         const scoreData = {
             userId: user.uid,
@@ -182,7 +182,8 @@ export async function saveScoreToCloud(skinKey, score, level, userName) {
             level: level,
             skin: skinKey,
             timestamp: serverTimestamp(),
-            date: new Date().toLocaleDateString('he-IL')
+            date: new Date().toLocaleDateString('he-IL'),
+            settings: settings || null
         };
         
         // שמירה ב-leaderboard הכללי - רק שיא אחד למשתמש

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -156,6 +156,12 @@ const STRINGS = {
     quizCorrect:      { he: '✅ נכון!', en: '✅ Correct!', ar: '✅ صحيح!', ru: '✅ Правильно!', fr: '✅ Correct !', es: '✅ ¡Correcto!' },
     quizWrong:        { he: '❌ טעות. התשובה הנכונה מסומנת.', en: '❌ Wrong. The correct answer is highlighted.', ar: '❌ خطأ. الإجابة الصحيحة مظلّلة.', ru: '❌ Неверно. Правильный ответ выделен.', fr: '❌ Faux. La bonne réponse est surlignée.', es: '❌ Incorrecto. La respuesta correcta está resaltada.' },
 
+    // ---- Entry settings view ----
+    esTitle:          { he: '⚙️ הגדרות משחק', en: '⚙️ Game Settings', ar: '⚙️ إعدادات اللعبة', ru: '⚙️ Настройки игры', fr: '⚙️ Paramètres de jeu', es: '⚙️ Ajustes del juego' },
+    esFilterAll:      { he: 'הכל', en: 'All', ar: 'الكل', ru: 'Все', fr: 'Tout', es: 'Todo' },
+    esFallbackNote:   { he: '⚠️ הגדרות לא נשמרו למשחק ישן זה — מוצגות ההגדרות הנוכחיות שלך', en: '⚠️ Settings not saved for this old game — showing your current settings', ar: '⚠️ لم تُحفظ الإعدادات لهذه اللعبة القديمة — عرض إعداداتك الحالية', ru: '⚠️ Настройки не сохранены для этой старой игры — показаны ваши текущие настройки', fr: '⚠️ Paramètres non sauvegardés pour cette ancienne partie — affichage de vos paramètres actuels', es: '⚠️ Ajustes no guardados para esta partida antigua — mostrando tus ajustes actuales' },
+    esDuration:       { he: '⏱️ זמן משחק', en: '⏱️ Game duration', ar: '⏱️ مدة اللعبة', ru: '⏱️ Длительность', fr: '⏱️ Durée de partie', es: '⏱️ Duración' },
+
     // ---- Language tab ----
     langTabTitle:     { he: 'בחר שפה', en: 'Choose Language', ar: 'اختر اللغة', ru: 'Выберите язык', fr: 'Choisir la langue', es: 'Elegir idioma' },
     langLabel:        { he: 'שפה / Language:', en: 'Language / שפה:', ar: 'اللغة:', ru: 'Язык:', fr: 'Langue :', es: 'Idioma:' },

--- a/test/index.html
+++ b/test/index.html
@@ -134,6 +134,30 @@
                 <button onclick="closeLeaderboard()" style="margin-top: 15px;" data-i18n="lbBack">חזרה</button>
             </div>
 
+            <!-- Entry Settings View -->
+            <div id="entry-settings-container" style="display: none; width: 100%; max-width: 400px; text-align: center;">
+                <h2 style="margin-bottom: 8px;" data-i18n="esTitle">⚙️ הגדרות משחק</h2>
+                <div id="es-meta" style="font-size: 0.8rem; opacity: 0.7; margin-bottom: 4px;"></div>
+                <div id="es-duration" style="font-size: 0.8rem; opacity: 0.7; margin-bottom: 12px; display:none;"></div>
+
+                <div id="es-filters" style="display:flex; flex-wrap:wrap; gap:5px; margin-bottom:12px; justify-content:center;">
+                    <button class="es-filter active" data-cat="all" onclick="setEntrySettingsFilter('all')" data-i18n="esFilterAll">הכל</button>
+                    <button class="es-filter" data-cat="device" onclick="setEntrySettingsFilter('device')" data-i18n="tabDevice">📱 מכשיר</button>
+                    <button class="es-filter" data-cat="controls" onclick="setEntrySettingsFilter('controls')" data-i18n="tabControls">🎮 שליטה</button>
+                    <button class="es-filter" data-cat="rules" onclick="setEntrySettingsFilter('rules')" data-i18n="tabRules">📜 כללים</button>
+                    <button class="es-filter" data-cat="edu" onclick="setEntrySettingsFilter('edu')" data-i18n="tabEdu">📚 חינוכי</button>
+                    <button class="es-filter" data-cat="lang" onclick="setEntrySettingsFilter('lang')" data-i18n="tabLang">🌐 שפה</button>
+                </div>
+
+                <div id="es-body"></div>
+
+                <div id="es-fallback-note" style="display:none; margin-top:10px;">
+                    <small style="opacity: 0.6;" data-i18n="esFallbackNote">⚠️ הגדרות לא נשמרו — מוצגות ההגדרות הנוכחיות שלך</small>
+                </div>
+
+                <button onclick="closeEntrySettings()" style="margin-top: 15px;" data-i18n="settingsBack">◀ חזרה</button>
+            </div>
+
             <div id="main-menu">
             <div class="skin-selector">
                 <div class="skin-option selected" data-skin="classic">

--- a/test/main.js
+++ b/test/main.js
@@ -92,6 +92,9 @@ console.log('✅ [INIT] Game loaded successfully');
 
 // ===== LEADERBOARD =====
 
+let _currentLeaderboardEntries = [];
+let _esActiveFilter = 'all';
+
 function showLeaderboard() {
     console.log('🏆 [LEADERBOARD] Opening leaderboard...');
     console.log('🏆 [LEADERBOARD] Hiding main menu');
@@ -125,6 +128,139 @@ function closeLeaderboard() {
     document.getElementById('floating-settings-btn').style.display = 'flex';
     console.log('✅ [LEADERBOARD] Leaderboard closed');
 }
+
+// ===== ENTRY SETTINGS VIEW =====
+
+function showEntrySettings(idx) {
+    const entry = _currentLeaderboardEntries[idx];
+    if (!entry) return;
+
+    const isFallback = !entry.settings;
+    const s = entry.settings || {
+        isMobile: deviceMode.isMobile,
+        controlType: keyBindings.controlType,
+        shoot: keyBindings.shoot,
+        ability: keyBindings.ability,
+        rightClickAbility: keyBindings.rightClickAbility,
+        enemiesShootThroughAsteroids: gameRules.enemiesShootThroughAsteroids,
+        playerShootThroughAsteroids: gameRules.playerShootThroughAsteroids,
+        eduEnabled: eduConfig.enabled,
+        eduSubject: eduConfig.subject,
+        eduGrade: eduConfig.grade,
+        lang: currentLang,
+        gameDuration: null,
+        startTime: null
+    };
+
+    document.getElementById('leaderboard-container').style.display = 'none';
+    const container = document.getElementById('entry-settings-container');
+    container.style.display = 'block';
+
+    // Meta info
+    const skinName = SKINS[entry.skin]?.name || entry.skin || '';
+    document.getElementById('es-meta').textContent =
+        `👤 ${entry.userName || 'Anonymous'} | ${(entry.score || 0).toLocaleString()} pts | ${t('levelWord')} ${entry.level}${skinName ? ' • ' + skinName : ''} | ${entry.date || ''}`;
+
+    // Duration
+    const durationEl = document.getElementById('es-duration');
+    if (s.gameDuration) {
+        const mins = Math.floor(s.gameDuration / 60000);
+        const secs = Math.floor((s.gameDuration % 60000) / 1000);
+        durationEl.textContent = `${t('esDuration')}: ${mins}:${String(secs).padStart(2, '0')}`;
+        durationEl.style.display = 'block';
+    } else {
+        durationEl.style.display = 'none';
+    }
+
+    // Fallback note
+    document.getElementById('es-fallback-note').style.display = isFallback ? 'block' : 'none';
+
+    // Store settings on container for filter updates
+    container._esSettings = s;
+
+    // Reset filter to "all"
+    _esActiveFilter = 'all';
+    document.querySelectorAll('.es-filter').forEach(b => b.classList.toggle('active', b.dataset.cat === 'all'));
+    renderEntrySettingsBody(s, 'all');
+}
+
+function closeEntrySettings() {
+    document.getElementById('entry-settings-container').style.display = 'none';
+    document.getElementById('leaderboard-container').style.display = 'block';
+}
+
+function setEntrySettingsFilter(cat) {
+    _esActiveFilter = cat;
+    document.querySelectorAll('.es-filter').forEach(b => b.classList.toggle('active', b.dataset.cat === cat));
+    const container = document.getElementById('entry-settings-container');
+    renderEntrySettingsBody(container._esSettings || {}, cat);
+}
+
+function renderEntrySettingsBody(s, cat) {
+    const langInfo = LANGUAGES.find(l => l.code === s.lang) || LANGUAGES[0];
+    const subjects = getSubjects();
+    const subjName = subjects.find(sub => sub.key === s.eduSubject)?.name || s.eduSubject || '-';
+
+    const fmtKey = (code) => {
+        if (!code) return '?';
+        if (code === 'Space') return 'Space';
+        if (code.startsWith('Key')) return code.replace('Key', '');
+        if (code.startsWith('Digit')) return code.replace('Digit', '');
+        return code;
+    };
+
+    const bool = (v) => v
+        ? `<span class="es-val-yes">✅ ${currentLang === 'en' ? 'Yes' : 'כן'}</span>`
+        : `<span class="es-val-no">❌ ${currentLang === 'en' ? 'No' : 'לא'}</span>`;
+
+    const row = (label, value) =>
+        `<div class="es-row"><span class="es-label">${label}</span><span class="es-value">${value}</span></div>`;
+
+    const groups = {
+        device: `<div class="es-group" data-cat="device">
+            <div class="es-group-title">${t('tabDevice')}</div>
+            ${row(t('deviceLabel'), s.isMobile
+                ? `📱 ${t('deviceMobile').replace(/^📱\s*/, '')}`
+                : `🖥️ ${t('deviceDesktop').replace(/^🖥️\s*/, '')}`)}
+        </div>`,
+
+        controls: `<div class="es-group" data-cat="controls">
+            <div class="es-group-title">${t('tabControls')}</div>
+            ${row(t('controlLabel'), s.controlType === 'mouse' ? t('controlMouse') : t('controlArrows'))}
+            ${row(t('shootKeyLabel'), `<kbd>${fmtKey(s.shoot)}</kbd>`)}
+            ${row(t('abilityKeyLabel'), `<kbd>${fmtKey(s.ability)}</kbd>`)}
+            ${row(t('rightClickLabel'), bool(s.rightClickAbility))}
+        </div>`,
+
+        rules: `<div class="es-group" data-cat="rules">
+            <div class="es-group-title">${t('tabRules')}</div>
+            ${row(t('enemiesAsteLabel'), bool(s.enemiesShootThroughAsteroids))}
+            ${row(t('playerAsteLabel'), bool(s.playerShootThroughAsteroids))}
+        </div>`,
+
+        edu: `<div class="es-group" data-cat="edu">
+            <div class="es-group-title">${t('tabEdu')}</div>
+            ${row(t('eduOnOffLabel'), s.eduEnabled
+                ? `✅ ${t('eduOn').replace(/^✅\s*/, '')}`
+                : `❌ ${t('eduOff').replace(/^❌\s*/, '')}`)}
+            ${s.eduEnabled ? row(t('subjectLabel'), subjName) : ''}
+            ${s.eduEnabled ? row(t('gradeLabel_'), gradeLabel(s.eduGrade || '1')) : ''}
+        </div>`,
+
+        lang: `<div class="es-group" data-cat="lang">
+            <div class="es-group-title">${t('tabLang')}</div>
+            ${row(t('langLabel'), `${langInfo.flag} ${langInfo.name}`)}
+        </div>`
+    };
+
+    document.getElementById('es-body').innerHTML =
+        cat === 'all' ? Object.values(groups).join('') : (groups[cat] || '');
+}
+
+// Export to window for HTML onclick
+window.showEntrySettings = showEntrySettings;
+window.closeEntrySettings = closeEntrySettings;
+window.setEntrySettingsFilter = setEntrySettingsFilter;
 
 async function displayLeaderboard(category) {
     console.log(`📊 [DISPLAY] Displaying leaderboard for category: ${category}`);
@@ -164,25 +300,27 @@ async function displayLeaderboard(category) {
         return;
     }
     
+    _currentLeaderboardEntries = leaderboard;
+
     const medals = ['🥇', '🥈', '🥉', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', '🔟'];
     console.log('📊 [DISPLAY] Generating HTML for entries...');
     const html = leaderboard.map((entry, index) => {
         console.log(`📊 [DISPLAY] Entry ${index + 1}:`, entry);
-        
+
         // Get skin name, or use the skin key if skin doesn't exist in SKINS
         let skinName = '';
         if (entry.skin) {
             if (SKINS[entry.skin]) {
                 skinName = `• ${SKINS[entry.skin].name}`;
             } else {
-                skinName = `• ${entry.skin}`; // Fallback to skin key if skin doesn't exist
+                skinName = `• ${entry.skin}`;
                 console.warn(`⚠️ [DISPLAY] Unknown skin: ${entry.skin}`);
             }
         }
-        
+
         // Get user name
         const userName = entry.userName || 'Anonymous';
-        
+
         return `
         <div class="lb-entry rank-${index + 1}">
             <div class="lb-rank">${medals[index] || (index + 1)}</div>
@@ -195,6 +333,7 @@ async function displayLeaderboard(category) {
                     ${t('levelWord')} ${entry.level} ${skinName} • ${entry.date}
                 </div>
             </div>
+            <button class="lb-settings-btn" onclick="showEntrySettings(${index})" title="${t('esTitle')}">⚙️</button>
         </div>
     `;
     }).join('');

--- a/test/styles.css
+++ b/test/styles.css
@@ -527,6 +527,98 @@ button:hover {
     font-size: 0.9rem;
 }
 
+.lb-settings-btn {
+    padding: 6px 9px;
+    font-size: 1rem;
+    background: rgba(0,242,255,0.08);
+    border: 1px solid rgba(0,242,255,0.25);
+    color: var(--primary);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s;
+    flex-shrink: 0;
+}
+
+.lb-settings-btn:hover {
+    background: rgba(0,242,255,0.2);
+    border-color: var(--primary);
+}
+
+/* Entry Settings View */
+#es-body {
+    background: rgba(0,0,0,0.5);
+    border: 1px solid var(--primary);
+    border-radius: 10px;
+    padding: 10px 12px;
+    max-height: 260px;
+    overflow-y: auto;
+    text-align: start;
+}
+
+.es-filter {
+    padding: 5px 10px;
+    font-size: 0.72rem;
+    background: rgba(255,255,255,0.07);
+    border: 1px solid rgba(255,255,255,0.2);
+    color: rgba(255,255,255,0.65);
+    border-radius: 14px;
+    cursor: pointer;
+    transition: all 0.2s;
+    font-family: 'Orbitron', sans-serif;
+}
+
+.es-filter.active {
+    background: rgba(0,242,255,0.18);
+    border-color: var(--primary);
+    color: var(--primary);
+}
+
+.es-group {
+    margin-bottom: 12px;
+}
+
+.es-group-title {
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: var(--primary);
+    margin-bottom: 6px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid rgba(0,242,255,0.25);
+}
+
+.es-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 3px 0;
+    font-size: 0.78rem;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+
+.es-label {
+    color: rgba(255,255,255,0.55);
+    flex: 1;
+    padding-inline-end: 8px;
+}
+
+.es-value {
+    color: white;
+    font-weight: bold;
+    text-align: end;
+}
+
+.es-val-yes { color: #2ecc71; }
+.es-val-no  { color: #e74c3c; }
+
+kbd {
+    background: rgba(255,255,255,0.12);
+    border: 1px solid rgba(255,255,255,0.25);
+    border-radius: 3px;
+    padding: 1px 6px;
+    font-size: 0.72rem;
+    font-family: monospace;
+}
+
 /* Special Ability Button */
 #special-ability-btn {
     position: fixed;

--- a/test/systems.js
+++ b/test/systems.js
@@ -101,13 +101,31 @@ export function damagePlayer(amount) {
         if (pauseOverlay) pauseOverlay.style.display = 'none';
 
         if (!state.isDebugGame) {
-            import('./data.js').then(module => {
-                // Get username from auth module
-                import('./auth.js').then(authModule => {
-                    const userName = authModule.currentUser?.displayName || 'Anonymous';
-                    module.saveScore(module.currentSkinKey, state.score, state.level, userName);
-                    console.log(`✅ [GAME OVER] Score saved for user: ${userName}`);
-                });
+            const gameDuration = Date.now() - (state.startTime || Date.now());
+            Promise.all([
+                import('./data.js'),
+                import('./auth.js'),
+                import('./education.js'),
+                import('./i18n.js')
+            ]).then(([dataModule, authModule, eduModule, i18nModule]) => {
+                const userName = authModule.currentUser?.displayName || 'Anonymous';
+                const settings = {
+                    isMobile: dataModule.deviceMode.isMobile,
+                    controlType: dataModule.keyBindings.controlType,
+                    shoot: dataModule.keyBindings.shoot,
+                    ability: dataModule.keyBindings.ability,
+                    rightClickAbility: dataModule.keyBindings.rightClickAbility,
+                    enemiesShootThroughAsteroids: dataModule.gameRules.enemiesShootThroughAsteroids,
+                    playerShootThroughAsteroids: dataModule.gameRules.playerShootThroughAsteroids,
+                    eduEnabled: eduModule.eduConfig.enabled,
+                    eduSubject: eduModule.eduConfig.subject,
+                    eduGrade: eduModule.eduConfig.grade,
+                    lang: i18nModule.currentLang,
+                    gameDuration,
+                    startTime: state.startTime || null
+                };
+                dataModule.saveScore(dataModule.currentSkinKey, state.score, state.level, userName, settings);
+                console.log(`✅ [GAME OVER] Score saved for user: ${userName}`);
             }).catch(err => {
                 console.error('❌ [GAME OVER] Save error:', err);
             });


### PR DESCRIPTION
- Leaderboard: each entry now has a gear ⚙️ button that opens a read-only
  settings view showing all categories (Device, Controls, Rules, Education,
  Language) with per-category filter buttons
- Old entries without saved settings show the current player's settings
  with a clear fallback notice
- Game save: records full settings snapshot at game-over (device, controls,
  game rules, education config, language, game duration, start timestamp)
- firestore-sync: settings object stored alongside every score document
- i18n: new translation keys for the settings view (6 languages)

https://claude.ai/code/session_01JgiJSQ43kRfsnWvdRmf6yx