### PR TITLE
Fix leaderboard cross-skin contamination and skin unlock persistence

### DIFF
--- a/.github/workflows/depoly-test.yml
+++ b/.github/workflows/depoly-test.yml
@@ -2,7 +2,7 @@ name: Deploy test
 on:
   push:
     branches:
-      - claude/character-starting-levels-ikootl
+      - claude/leaderboard-sync-issues-5yoagu
 
 permissions:
   contents: write

--- a/.github/workflows/depoly-test.yml
+++ b/.github/workflows/depoly-test.yml
@@ -1,8 +1,8 @@
 name: Deploy test
 on:
   push:
-    branches:
-      - claude/leaderboard-sync-issues-5yoagu
+    branches-ignore:
+      - main
 
 permissions:
   contents: write

--- a/data.js
+++ b/data.js
@@ -436,6 +436,10 @@ export async function loadUnlockedSkins() {
     }
 }
 
+export function refreshUnlockedSkins(skins) {
+    unlockedSkins = [...skins];
+}
+
 export async function unlockSkin(skinKey) {
     if (!unlockedSkins.includes(skinKey)) {
         unlockedSkins.push(skinKey);

--- a/firestore-sync.js
+++ b/firestore-sync.js
@@ -295,14 +295,21 @@ export async function getLeaderboardFromCloud(skinKey = 'overall') {
             }
         }
 
-        // Also fetch all game sessions for complete filter coverage
+        // Also fetch game sessions for complete filter coverage.
+        // When viewing a specific skin's leaderboard, only include sessions for
+        // that skin so dragon/joker sessions don't leak into the vortex tab.
         try {
             const sessSnap = await getDocs(query(
                 collection(db, 'game_sessions'),
                 orderBy('level', 'desc'),
                 limit(500)
             ));
-            sessSnap.forEach((d) => collected.push({ id: d.id, ...d.data() }));
+            sessSnap.forEach((d) => {
+                const data = d.data();
+                if (skinKey === 'overall' || !data.skin || data.skin === skinKey) {
+                    collected.push({ id: d.id, ...data });
+                }
+            });
         } catch (e) {
             console.warn('⚠️ [CLOUD] game_sessions fetch failed:', e);
         }
@@ -720,7 +727,7 @@ export async function syncAllData() {
         const localDeviceMode = JSON.parse(getCookie('deviceMode') || '{}');
         const localCustomGoals = JSON.parse(getCookie('customSpeedrunGoals') || '[]');
 
-        const [, , mergedCoins, mergedUpgrades, mergedAchievements, mergedKeyBindings, mergedGameRules, mergedDeviceMode, mergedCustomGoals] = await Promise.all([
+        const [mergedSkins, , mergedCoins, mergedUpgrades, mergedAchievements, mergedKeyBindings, mergedGameRules, mergedDeviceMode, mergedCustomGoals] = await Promise.all([
             syncUnlockedSkins(),
             syncMaxLevel(),
             syncCoins(localCoins),
@@ -743,6 +750,9 @@ export async function syncAllData() {
         }
         if (mergedAchievements !== undefined) {
             localStorage.setItem('achievements_v1', JSON.stringify(mergedAchievements));
+        }
+        if (mergedSkins !== undefined && typeof window.__onUnlockedSkinsSynced === 'function') {
+            window.__onUnlockedSkinsSynced(mergedSkins);
         }
         if (mergedKeyBindings !== undefined) {
             setCookie('keyBindings', JSON.stringify(mergedKeyBindings));

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import { DOM, SKINS, state, resetState, setCurrentSkin, currentSkinKey, loadUnlockedSkins, isSkinUnlocked, unlockSkin, saveMaxLevel, getMaxLevel, getLeaderboard, saveScore, keyBindings, loadKeyBindings, setKeyBinding, gameRules, loadGameRules, setGameRule, deviceMode, loadDeviceMode, setDeviceMode, addCoins, initCoinsUI, UPGRADES, getOwnedUpgrades, hasUpgrade, buyUpgrade, removeUpgrade, resetCoins, getCoins, getDisabledUpgrades, disableUpgrade, enableUpgrade, isUpgradeDisabled, isUpgradeActive, SPEEDRUN_GOALS, getCustomSpeedrunGoals, addCustomSpeedrunGoal, removeCustomSpeedrunGoal, getSpeedrunLeaderboard } from './data.js';
+import { DOM, SKINS, state, resetState, setCurrentSkin, currentSkinKey, loadUnlockedSkins, isSkinUnlocked, unlockSkin, refreshUnlockedSkins, saveMaxLevel, getMaxLevel, getLeaderboard, saveScore, keyBindings, loadKeyBindings, setKeyBinding, gameRules, loadGameRules, setGameRule, deviceMode, loadDeviceMode, setDeviceMode, addCoins, initCoinsUI, UPGRADES, getOwnedUpgrades, hasUpgrade, buyUpgrade, removeUpgrade, resetCoins, getCoins, getDisabledUpgrades, disableUpgrade, enableUpgrade, isUpgradeDisabled, isUpgradeActive, SPEEDRUN_GOALS, getCustomSpeedrunGoals, addCustomSpeedrunGoal, removeCustomSpeedrunGoal, getSpeedrunLeaderboard } from './data.js';
 import { updatePlayerPos, movePlayer, updateHPUI, updateAmmoUI, shoot, showFloatingMessage, useVortexLaser, usePhoenixFeathers, useJokerChaos, useDragonFire, rechargeAmmo } from './systems.js';
 import { handleSpawning } from './systems.js';
 import { updateBullets, updateEnemyBullets, updateBurgers, updateIngredients, updateAsteroids, updateEnemies, updateLightnings } from './updates.js';
@@ -21,6 +21,11 @@ loadKeyBindings();
 window.__onKeyBindingsSynced = (merged) => {
     Object.assign(keyBindings, merged);
     console.log('🎮 [KEYS] Reloaded from cloud sync:', keyBindings);
+};
+// After cloud sync, refresh in-memory unlocked skins and update the skin selector
+window.__onUnlockedSkinsSynced = (skins) => {
+    refreshUnlockedSkins(skins);
+    updateSkinOptions();
 };
 loadGameRules();
 loadDeviceMode();


### PR DESCRIPTION
## Summary

- **Bug 1 + 3**: `getLeaderboardFromCloud` fetched ALL `game_sessions` without skin filtering — dragon/joker sessions leaked into the vortex tab. Because client-side dedup is by `userName` only, a player's dragon session (higher level) displaced their vortex session, hiding their actual vortex record.
- **Bug 2**: `syncAllData` discarded the merged skins result, so the in-memory `unlockedSkins` array in `data.js` was never refreshed after auth fired. A skin unlocked during a session (e.g. dragon at level 15) could appear missing after refresh if the async load raced with `updateSkinOptions`.

## Changes

- `firestore-sync.js` — filter `game_sessions` entries by `skinKey` when not `'overall'`; capture `mergedSkins` in `syncAllData` and emit `window.__onUnlockedSkinsSynced` callback
- `data.js` — export `refreshUnlockedSkins(skins)` to update the in-memory array without a full cloud round-trip
- `main.js` — import `refreshUnlockedSkins`; register `window.__onUnlockedSkinsSynced` handler (mirrors the existing `__onKeyBindingsSynced` pattern) to refresh the skin selector after cloud sync

## Test plan

- [ ] Play with vortex skin → open vortex leaderboard → confirm only vortex entries appear (no dragon/joker rows)
- [ ] Play with vortex skin → confirm your new score appears in the vortex leaderboard
- [ ] Unlock dragon (reach level 15) → refresh the page → confirm dragon skin is still unlocked in the skin selector
- [ ] Confirm overall leaderboard still shows all skins mixed together

https://claude.ai/code/session_015omWJcKbRUzjWisHA9PM5t

---
_Generated by [Claude Code](https://claude.ai/code/session_015omWJcKbRUzjWisHA9PM5t)_